### PR TITLE
Adds conditional to the resources

### DIFF
--- a/input/v1beta1/resources_common.go
+++ b/input/v1beta1/resources_common.go
@@ -46,6 +46,9 @@ type ComposedTemplate struct {
 	// +optional
 	Base *runtime.RawExtension `json:"base,omitempty"`
 
+	// Condition defines a CEL condition whether this function will render
+	Condition *ConditionSpec `json:"condition,omitempty"`
+
 	// Patches to and from the composed resource.
 	// +optional
 	Patches []Patch `json:"patches,omitempty"`


### PR DESCRIPTION
This enables a go-template step to conditionally add say VPCDHPCOptions while still using a common set of patchsets across all desired resources.

The following snippet will now be valid when VPCDHPCOptions (resource name: vpc-dhcp-options) are present or not.  

```yaml
- step: patch-and-transform
      functionRef:
        name: function-patch-and-transform
      input:
        apiVersion: pt.fn.crossplane.io/v1beta1
        kind: Resources
        resources:
          - name: vpc-dhcp-options
            condition:
              expression: '"vpc-dhcp-options" in desired.resources'
            patches:
              - patchSetName: deletion-policy
                type: PatchSet
              - patchSetName: aws-provider-config-ref-patchset
                type: PatchSet
              - patchSetName: region-patchset
                type: PatchSet
```